### PR TITLE
Fix #71: peak label follows the peak during interactive drag

### DIFF
--- a/fitspy/apps/interactive_bounds_pg.py
+++ b/fitspy/apps/interactive_bounds_pg.py
@@ -13,7 +13,7 @@ from fitspy.apps.pyside.utils import convert_color_pg
 class InteractiveBounds(QtCore.QObject):
 
     def __init__(self, ax, spectrum, peak_model_name,
-                 cmap=None, bind_func=None, enable_add_peak=False):
+                 cmap=None, bind_func=None, move_func=None, enable_add_peak=False):
         super().__init__()
 
         self.ax = ax
@@ -21,6 +21,7 @@ class InteractiveBounds(QtCore.QObject):
         self.peak_model_name = peak_model_name
         self.cmap = cmap or CMAP
         self.bind_func = bind_func
+        self.move_func = move_func
         self.enable_add_peak = enable_add_peak
 
         self.bboxes = []
@@ -32,7 +33,8 @@ class InteractiveBounds(QtCore.QObject):
         self.cmap = cmap
 
     def add_bbox(self, k, peak_model, is_visible=False):
-        bbox = BBox(self.ax, self.spectrum, peak_model, is_visible=is_visible)
+        bbox = BBox(self.ax, self.spectrum, peak_model, is_visible=is_visible,
+                    on_change=self.move_func)
         bbox.set_color(self.cmap(k % self.cmap.N))
         bbox.update()
         self.bboxes.append(bbox)
@@ -95,13 +97,15 @@ class InteractiveBounds(QtCore.QObject):
 
 class BBox(BBoxParamsMixin):
 
-    def __init__(self, ax, spectrum, peak_model, is_visible=True, color='b', ratio=0.5):
+    def __init__(self, ax, spectrum, peak_model, is_visible=True, color='b', ratio=0.5,
+                 on_change=None):
 
         self.ax = ax
         self.spectrum = spectrum
         self.peak_model = peak_model
         self.color = color
         self.ratio = ratio
+        self.on_change = on_change
 
         self.x = spectrum.x
         self.y = spectrum.y
@@ -203,6 +207,10 @@ class BBox(BBoxParamsMixin):
                 self.dfwhm[0] = self.dfwhm[1]
 
         self.update()
+
+        # notify listeners (e.g. to keep the peak label following the peak live)
+        if self.on_change is not None:
+            self.on_change()
 
     def contains(self, x, y):
         return (self.contains_rect(self.rect_x0, x, y) or

--- a/fitspy/apps/pyside/components/plot/backend_manager.py
+++ b/fitspy/apps/pyside/components/plot/backend_manager.py
@@ -200,6 +200,10 @@ class MplLikeAxes:
         self.plot_item.addItem(item)
         self._lines.append(item)
 
+        # keep track of every scene item this annotation created so a caller can
+        # remove the whole annotation later (e.g. to reposition it during a drag)
+        item.annotation_items = [item]
+
         arrowprops = kwargs.get('arrowprops')
         if arrowprops:
             arrow = pg.ArrowItem(pos=(x + offset_x, y + offset_y),
@@ -209,6 +213,7 @@ class MplLikeAxes:
             arrow.setStyle(angle=math.degrees(math.atan2(dy, dx)))
             self.plot_item.addItem(arrow)
             self._lines.append(arrow)
+            item.annotation_items.append(arrow)
 
         return item
 

--- a/fitspy/apps/pyside/components/plot/model.py
+++ b/fitspy/apps/pyside/components/plot/model.py
@@ -50,6 +50,9 @@ class Model(QObject):
         self.nearest_lines = []
         self.ibounds = None
         self._Y = []
+        self.peak_label_items = []  # scene items of the peak-label annotations
+        self._ax = None  # last axes used, for live (drag-time) label refresh
+        self._view_options = {}  # last view options, for live label refresh
 
     def set_spectrum_attr(self, fname, attr, value):
         # .json model's "dummy spectrum" is not stored in self.spectra
@@ -356,7 +359,8 @@ class Model(QObject):
                                          self.current_spectra[0],
                                          self.peak_model,
                                          cmap=DEFAULTS["peaks_cmap"],
-                                         bind_func=self.refresh)
+                                         bind_func=self.refresh,
+                                         move_func=self.refresh_peak_labels)
 
     # @measure_time
     def update_spectraplot(self, ax, view_options):
@@ -366,6 +370,9 @@ class Model(QObject):
 
         ax.clear()
         self.tmp = []
+        self.peak_label_items = []  # cleared by ax.clear(); drop stale references
+        self._ax = ax
+        self._view_options = view_options
 
         if not self.current_spectra:
             ax.draw_idle()
@@ -429,45 +436,71 @@ class Model(QObject):
             self.ibounds.set_visible(view_options["Interactive bounds"])
 
         # Add Peak labels annotations
-        if view_options.get("Peak labels", True):
-            dy_label = LABEL_OFFSET_RATIO * spectrum.y.max()
-            annotation_y = []
-            for i, label in enumerate(spectrum.peak_labels):
-                if not label:
-                    continue
-                model = spectrum.peak_models[i]
-                x_label = model.param_hints["x0"]["value"]
-                with empty_expr(model):
-                    params = model.make_params()
-                y_label = model.eval(params, x=x_label)
-
-                if view_options.get("Subtract bkg+baseline") and spectrum.bkg_models:
-                    for bkg_model in spectrum.bkg_models:
-                        y_label -= bkg_model.eval(bkg_model.make_params(), x=x_label)
-
-                xy = (x_label, y_label + dy_label)
-                annotation_y.append(y_label + 2 * dy_label)
-                ax.annotate(label,
-                            xy=xy,
-                            xycoords="data",
-                            textcoords="offset points",
-                            ha="center",
-                            va="top",
-                            size=14,
-                            arrowprops={"fc": 'k', "arrowstyle": '->'},
-                            annotation_clip=True)
-
-            # Adjust y-axis to contain peak labels
-            if annotation_y:
-                max_annotation_y = max(annotation_y)
-                current_ylim = ax.get_ylim()
-                if max_annotation_y > current_ylim[1]:
-                    ax.set_ylim(top=max_annotation_y + YLIM_BUFFER_RATIO * spectrum.y.max())
+        self.draw_peak_labels(ax, spectrum, view_options)
 
         ax.plot_item.setLogMode(x=view_options.get("X-log", False),
                                 y=view_options.get("Y-log", False))
 
         ax.draw_idle()
+
+    def draw_peak_labels(self, ax, spectrum, view_options, adjust_ylim=True):
+        """(Re)draw the peak-label annotations for `spectrum`.
+
+        Any previously drawn peak labels are removed first, so this can be called
+        repeatedly (e.g. while a peak is dragged) to keep labels on their peaks.
+        """
+        for item in self.peak_label_items:
+            if item in ax.plot_item.items:
+                ax.plot_item.removeItem(item)
+            if item in ax._lines:
+                ax._lines.remove(item)
+        self.peak_label_items = []
+
+        if not view_options.get("Peak labels", True):
+            return
+
+        dy_label = LABEL_OFFSET_RATIO * spectrum.y.max()
+        annotation_y = []
+        for i, label in enumerate(spectrum.peak_labels):
+            if not label:
+                continue
+            model = spectrum.peak_models[i]
+            x_label = model.param_hints["x0"]["value"]
+            with empty_expr(model):
+                params = model.make_params()
+            y_label = model.eval(params, x=x_label)
+
+            if view_options.get("Subtract bkg+baseline") and spectrum.bkg_models:
+                for bkg_model in spectrum.bkg_models:
+                    y_label -= bkg_model.eval(bkg_model.make_params(), x=x_label)
+
+            xy = (x_label, y_label + dy_label)
+            annotation_y.append(y_label + 2 * dy_label)
+            annotation = ax.annotate(label,
+                                     xy=xy,
+                                     xycoords="data",
+                                     textcoords="offset points",
+                                     ha="center",
+                                     va="top",
+                                     size=14,
+                                     arrowprops={"fc": 'k', "arrowstyle": '->'},
+                                     annotation_clip=True)
+            self.peak_label_items.extend(annotation.annotation_items)
+
+        # Adjust y-axis to contain peak labels
+        if adjust_ylim and annotation_y:
+            max_annotation_y = max(annotation_y)
+            current_ylim = ax.get_ylim()
+            if max_annotation_y > current_ylim[1]:
+                ax.set_ylim(top=max_annotation_y + YLIM_BUFFER_RATIO * spectrum.y.max())
+
+    def refresh_peak_labels(self):
+        """Reposition peak labels in place, without a full replot (used on drag)."""
+        if self._ax is None or not self.current_spectra:
+            return
+        self.draw_peak_labels(self._ax, self.current_spectra[0], self._view_options,
+                              adjust_ylim=False)
+        self._ax.draw_idle()
 
     def apply_model(self, model_dict=None, fnames=None, ncpus=None):
         """Apply model to the selected spectra"""

--- a/tests/test_gui_peak_label_follows_drag.py
+++ b/tests/test_gui_peak_label_follows_drag.py
@@ -1,0 +1,100 @@
+"""
+Regression test for issue #71:
+'Peaks Label not following when dragging peak interactively'.
+
+When a peak is dragged interactively (pyqtgraph backend), its text label must
+track the peak in real time - not only after the mouse is released.
+"""
+import numpy as np
+import pytest
+
+pg = pytest.importorskip("pyqtgraph")
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+
+import matplotlib
+
+from fitspy.core.spectrum import Spectrum
+from fitspy.apps.pyside import DEFAULTS
+from fitspy.apps.pyside.components.plot.backend_manager import MplLikeAxes
+from fitspy.apps.pyside.components.plot.model import Model
+
+
+VIEW_OPTIONS = {
+    "Weights": False,
+    "Outliers": False,
+    "Outliers limits": False,
+    "Negative values": False,
+    "Peaks": True,
+    "Peak decomposition": False,
+    "Noise level": False,
+    "Baseline": False,
+    "Background": False,
+    "Fit": False,
+    "Subtract bkg+baseline": False,
+    "Residual": False,
+    "Legend": False,
+    "Interactive bounds": True,
+    "Peak labels": True,
+    "X-log": False,
+    "Y-log": False,
+}
+
+
+def _qapp():
+    return QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+
+def _make_spectrum():
+    spectrum = Spectrum()
+    x = np.arange(0.0, 100.0)
+    y = 1000.0 * np.exp(-((x - 50.0) ** 2) / (2 * 5.0 ** 2)) + 1.0
+    spectrum.x, spectrum.y = x, y
+    spectrum.x0, spectrum.y0 = x.copy(), y.copy()
+    spectrum.add_peak_model("Lorentzian", x0=50.0)  # label defaults to "1"
+    return spectrum
+
+
+def _label_x(ax, text):
+    """x-position (data coords) of the peak-label TextItem matching `text`."""
+    xs = []
+    for item in ax.plot_item.items:
+        if isinstance(item, pg.TextItem):
+            try:
+                plain = item.textItem.toPlainText()
+            except Exception:
+                plain = None
+            if plain == text:
+                xs.append(item.pos().x())
+    assert len(xs) == 1, f"expected exactly one label {text!r}, found {len(xs)}"
+    return xs[0]
+
+
+def test_peak_label_follows_peak_during_interactive_drag(monkeypatch):
+    # the running app replaces this string with a real mpl colormap at startup;
+    # patch it here without polluting the shared DEFAULTS for other tests
+    monkeypatch.setitem(DEFAULTS, "peaks_cmap", matplotlib.colormaps["tab10"])
+
+    _qapp()
+    plot_widget = pg.PlotWidget()
+    ax = MplLikeAxes(plot_widget.getPlotItem())
+
+    spectrum = _make_spectrum()
+    model = Model()
+    model.current_spectra = [spectrum]
+    model.peak_model = "Lorentzian"
+    model.init_ibounds(ax)
+    model.update_spectraplot(ax, VIEW_OPTIONS)
+
+    # label starts at the peak position
+    assert _label_x(ax, "1") == pytest.approx(50.0)
+
+    # simulate an interactive drag of the peak to x0 = 70 (no mouse release)
+    bbox = model.ibounds.bboxes[0]
+    bbox.dragging = "all"
+    bbox.last_x = bbox.x0
+    bbox.on_move(70.0)
+
+    # param hint moved...
+    assert spectrum.peak_models[0].param_hints["x0"]["value"] == pytest.approx(70.0)
+    # ...and the label must have followed WITHOUT a full replot / release
+    assert _label_x(ax, "1") == pytest.approx(70.0)


### PR DESCRIPTION
Fixes #71.

## Problem

When dragging a peak interactively (pyqtgraph interactive bounds), its text label did **not** move with the peak — it stayed at the old position and only jumped to the new one once the mouse was released.

## Root cause

Peak-label annotations (`pg.TextItem` + `pg.ArrowItem`) are only (re)created during a full replot in `Model.update_spectraplot`. While a peak is being dragged, `BBox.on_move` updates the bbox widgets and the model's `param_hints`, but a full replot only happens on mouse **release** (`bind_func=self.refresh`). So the label lagged behind until release.

## Fix

- **`backend_manager.py`** — `annotate()` now records the scene items it creates on `item.annotation_items`, so a caller can remove the whole annotation (text + arrow) later.
- **`interactive_bounds_pg.py`** — `InteractiveBounds` gains a `move_func`, wired into each `BBox` as an `on_change` callback that fires at the end of `BBox.on_move` (i.e. live, while the button is held).
- **`plot/model.py`** — the label-drawing loop is extracted into a re-entrant `draw_peak_labels()` (removes previously drawn labels first), plus a `refresh_peak_labels()` that repositions labels in place with **no full replot and no bbox rebuild**. `init_ibounds` passes it as `move_func`.

Labels are recomputed from `param_hints` (kept up to date by the shared `update_params`), so they track the peak correctly for every drag mode (move / x0-bounds / fwhm).

## Tests

- New regression test `tests/test_gui_peak_label_follows_drag.py` — asserts the label `TextItem` tracks the peak's `x0` mid-drag (before release). Fails on `main`, passes here.
- Full suite: **43 passed** (42 previous + 1 new), no regressions.

## Screenshots

Mid-drag (before mouse release):

<img width="1210" height="990" alt="issue71_before_after" src="https://github.com/user-attachments/assets/0a80cd0c-e104-4ef4-b08f-a03dd373db49" />

