### PR TITLE
Fix #25: require superqt>=0.8.2 to avoid QLabeledRangeSlider teardown segfault

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "lmfit",
     "parse",
     "dill",
-    "superqt[cmap]",
+    "superqt[cmap]>=0.7.2",
     "pyqt-toast-notification",
     "rosettasciio",
     "h5py",


### PR DESCRIPTION
## Summary

Fixes #25 — the PySide GUI intermittently crashes with an access violation (`Process finished with exit code -1073741819 (0xC0000005)`) on Windows.

## Root cause

The 2D map view (`fitspy/apps/pyside/components/plot/map2d_plot.py`) uses superqt's `QLabeledDoubleRangeSlider`. In **superqt 0.7.1**, `QLabeledRangeSlider` reassigns inherited Qt bound-signal attributes at the instance level (the `_rename_signals` / `self.sliderPressed = self._sliderPressed`-style "signal renaming"). This corrupts Qt's signal bookkeeping and triggers a segfault during widget/interpreter teardown. The crash is timing/GC-dependent, which is why it appeared intermittently and only in certain call contexts (matching upstream pyapp-kit/superqt#273).

## Proof it is fixed upstream

superqt reduced that signal reassignment in **PR pyapp-kit/superqt#283**, released in **v0.7.2**. Bisecting with the upstream reproducer on **PySide6 6.8.1** (same reproducer as superqt#273):

| superqt | crashes |
|--------:|:-------:|
| 0.7.1   | 30 / 30 |
| **0.7.2** | **0 / 30** |
| 0.7.3   | 0 / 30  |
| 0.8.0   | 0 / 30  |

`#283` is the only slider-touching commit in the 0.7.2 release, so the bisect isolates it as the fix.

## Change

Pin the dependency to the latest stable superqt:

```diff
-    "superqt[cmap]",
+    "superqt[cmap]>=0.8.2",
```

This guarantees users get a superqt without the teardown crash (any `>=0.7.2` is safe; `>=0.8.2` simply tracks latest stable).
